### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ git clone https://github.com/acronis/perfkit.git
 
 ### Using benchmark library
 
-`go get github.com/acronis/perfkit/benchmark`
+`go install github.com/acronis/perfkit/benchmark@latest`
 
 ```go
 package main


### PR DESCRIPTION
Newer versions of Go don't allow to download and install a binary directly to `$GOPATH/bin`

Error:
```
# go get github.com/acronis/perfkit/benchmark
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```